### PR TITLE
prevent check-terraform-lock from creating dumb files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,9 @@
 - id: check-terraform-lock
   name: check-terraform-lock
   description: make sure your terraform lock file contains provider hashes for both macOS and linux
-  entry: terraform providers lock -platform=darwin_arm64 -platform=darwin_amd64 -platform=linux_amd64
-  language: system
+  entry: bin/check-terraform-lock.sh
+  language: script
   files: .terraform.lock.hcl
-  pass_filenames: false
 - id: terraform-fmt
   name: terraform-fmt
   description: autoformat terraform source code

--- a/bin/check-terraform-lock.sh
+++ b/bin/check-terraform-lock.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+    for file in "$@";
+    do
+        base_dir="$(dirname "${file}")"
+        terraform -chdir="${base_dir}" providers lock \
+            -platform=darwin_arm64 \
+            -platform=darwin_amd64 \
+            -platform=linux_amd64
+    done
+}
+
+main "$@"


### PR DESCRIPTION
when running `pre-commit run --all-files` in a repo, the `check-terraform-lock` command would run _even if you don't have a terraform lockfile in your current directory._ This causes a dumb file to be created with a terraform-generated comment inside. This will be annoying for our repos that use an "infra" directory for terraform code.