### PR TITLE
add `just --fmt`  pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -25,10 +25,10 @@
 - id: just-fmt
   name: just-fmt
   description: format `justfile` using `just --unstable --fmt`
-  entry: just --unstable --fmt --justfile
-  language: system
+  entry: bin/just-fmt.sh
+  language: script
   pass_filenames: true
-  files: '^(Justfile|justfile|\.just)$'
+  files: '(^|/)(Justfile|justfile|\.just)$'
 
 - id: ruff-lint
   name: ruff-lint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,6 +22,14 @@
   types:
     - terraform
 
+- id: just-fmt
+  name: just-fmt
+  description: format `justfile` using `just --unstable --fmt`
+  entry: just --unstable --fmt --justfile
+  language: system
+  pass_filenames: true
+  files: '^(Justfile|justfile|\.just)$'
+
 - id: ruff-lint
   name: ruff-lint
   entry: ruff check . --fix --exit-non-zero-on-fix

--- a/bin/just-fmt.sh
+++ b/bin/just-fmt.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+    for file in "$@";
+    do
+        just --unstable --fmt --justfile "${file}"
+    done
+}
+
+main "$@"


### PR DESCRIPTION
add just formatter pre-commit hook 

https://just.systems/man/en/formatting-and-dumping-justfiles.html

the formatter output also confirms the [editorconfig setting for 4 spaces](https://github.com/thermondo/dev-toolkit/blob/428bde39f011c1ce4fb2d8b201cb391e90ea5680/standards/.editorconfig#L16-L17). 