### PR TITLE
just-fmt: fix regex to support *.just

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -28,7 +28,7 @@
   entry: bin/just-fmt.sh
   language: script
   pass_filenames: true
-  files: '(^|/)(Justfile|justfile|\.just)$'
+  files: '(^|/)(Justfile|justfile|[^/]+\.just)$'
 
 - id: ruff-lint
   name: ruff-lint


### PR DESCRIPTION
somehow the correct regex didn't end up in the last PR... 

now tested in https://github.com/thermondo/dev-toolkit/pull/6