### PR TITLE
feat(pre-commit-hooks): add mypy hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -43,3 +43,16 @@
   language: system
   types:
     - python
+
+- id: mypy
+  name: mypy
+  entry: mypy
+  language: system
+  # Mypy uses a sqlite-backed cache; serial execution avoids intermittent
+  # "database is locked" failures when pre-commit would otherwise run it concurrently.
+  require_serial: true
+  args:
+    # Show tracebacks if mypy crashes.
+    - --show-traceback
+  types:
+    - python

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Example usage:
 # .pre-commit-config.yaml in your repository
 repos:
   - repo: https://github.com/thermondo/pre-commit-hooks
-    rev: v1.0.2
+    rev: vX.Y.Z
     hooks:
       - id: check-terraform-lock
       - id: terraform-fmt
+      - id: mypy
       - id: ruff-lint
       - id: ruff-format
 
@@ -36,3 +37,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 ```
+
+The `mypy` hook runs with `require_serial: true` to avoid intermittent
+`database is locked` failures from mypy's sqlite-backed cache when pre-commit
+would otherwise run it concurrently.


### PR DESCRIPTION
Run mypy with `require_serial: true` because its sqlite-backed cache can hit intermittent `database is locked` failures when pre-commit schedules concurrent runs.